### PR TITLE
Update pulumi-terraform to 65eb36cfeb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform v0.12.0-rc1.0.20190509225429-28b2383eacae
 	github.com/pkg/errors v0.8.0
 	github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0
-	github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d
+	github.com/pulumi/pulumi-terraform v0.18.3-0.20190620225652-65eb36cfebb1
 	github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709
 	github.com/terraform-providers/terraform-provider-mysql v1.5.2
 )

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ github.com/pulumi/pulumi-terraform v0.15.1/go.mod h1:j1Hb86i+cujAPoQwDRPlZa6T6cM
 github.com/pulumi/pulumi-terraform v0.18.2 h1:87eFAASBmHCH41OlcGZAydGgSYFTIPFoKjzaJ8Edw5M=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d h1:ObOJbSfTnJ8IzrTw7pVcckU+R0yMEyV4mXdQ+xH+j8w=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
+github.com/pulumi/pulumi-terraform v0.18.3-0.20190620225652-65eb36cfebb1 h1:T9LXyH3t0tAwDowydQDIntfLEsPsowtmzZd7Z/6YAIw=
+github.com/pulumi/pulumi-terraform v0.18.3-0.20190620225652-65eb36cfebb1/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54/go.mod h1:1NF/j951kWm+ZnRXpOkBqweImgwhlzFVwTA4A0V7TEU=

--- a/sdk/python/README.rst
+++ b/sdk/python/README.rst
@@ -21,13 +21,13 @@ To use from JavaScript or TypeScript in Node.js, install using either
 
 ::
 
-   $ npm install @pulumi/mysql
+    $ npm install @pulumi/mysql
 
 or ``yarn``:
 
 ::
 
-   $ yarn add @pulumi/mysql
+    $ yarn add @pulumi/mysql
 
 Python
 ~~~~~~
@@ -36,7 +36,7 @@ To use from Python, install using ``pip``:
 
 ::
 
-   $ pip install pulumi_mysql
+    $ pip install pulumi_mysql
 
 Go
 ~~
@@ -45,7 +45,7 @@ To use from Go, use ``go get`` to grab the latest version of the library
 
 ::
 
-   $ go get github.com/pulumi/pulumi-mysql/sdk/go/...
+    $ go get github.com/pulumi/pulumi-mysql/sdk/go/...
 
 Configuration
 -------------


### PR DESCRIPTION
This PR updates `pulumi-terraform` to [65eb36cfeb](https://github.com/pulumi/pulumi-terraform/commit/65eb36cfebb1c6261d1859e75b33fd01b90cbba0), and re-runs code generation